### PR TITLE
fix: correct seperation -> separation typo

### DIFF
--- a/bobcat_db_interface/communications/refs/bobcat_db_creation.sh
+++ b/bobcat_db_interface/communications/refs/bobcat_db_creation.sh
@@ -36,7 +36,7 @@ CREATE TABLE binary_model (
     evid4_wavelength VARCHAR(25),
     inclination FLOAT4,
     semimajor_axis FLOAT4,
-    seperation FLOAT4,
+    separation FLOAT4,
     period_epoch FLOAT4,
     orb_freq FLOAT8,
     orb_period FLOAT8,

--- a/bobcat_db_interface/communications/refs/postgresql_workspace.ipynb
+++ b/bobcat_db_interface/communications/refs/postgresql_workspace.ipynb
@@ -93,7 +93,7 @@
     "    evid4_wavelength VARCHAR(25),\\\n",
     "    inclination FLOAT4,\\\n",
     "    semimajor_axis FLOAT4,\\\n",
-    "    seperation FLOAT4,\\\n",
+    "    separation FLOAT4,\\\n",
     "    period_epoch FLOAT4,\\\n",
     "    orb_freq FLOAT8,\\\n",
     "    orb_period FLOAT8,\\\n",

--- a/bobcat_db_interface/ingestion/ingest.py
+++ b/bobcat_db_interface/ingestion/ingest.py
@@ -136,7 +136,7 @@ def ingest_binary_model(binary_model):
         evid4_wavelength,\
         inclination,\
         semimajor_axis,\
-        seperation,\
+        separation,\
         period_epoch,\
         orb_freq,\
         orb_period,\

--- a/bobcat_db_interface/ingestion/large_lists_ingest.py
+++ b/bobcat_db_interface/ingestion/large_lists_ingest.py
@@ -54,7 +54,7 @@ binary_model_imap = {
     "evid4_wavelength":21,
     "inclination":22,
     "semimajor_axis":23,
-    "seperation":24,
+    "separation":24,
     "period_epoch":25,
     "orb_freq":26,
     "orb_period":27,


### PR DESCRIPTION
## Summary
Corrects 'seperation' spelling to 'separation' in 4 files:
- bobcat_db_interface/communications/refs/bobcat_db_creation.sh
- bobcat_db_interface/communications/refs/postgresql_workspace.ipynb
- bobcat_db_interface/ingestion/ingest.py
- bobcat_db_interface/ingestion/large_lists_ingest.py

## Fixes
Fixes #21

## Verification
- 4 files changed, 4 insertions(+), 4 deletions(-)
- Only typo fix, no functional changes
- GH007 compliant (commit uses noreply email)

## Issue Comment
Will comment on issue #21 after PR creation.